### PR TITLE
Modify InteractionContext.member to return Member instead of User

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The `ctx` parameter is an instance of `InteractionContext`
 - `.message` [discord.Message](https://discordpy.readthedocs.io/en/latest/api.html#discord.Message) : The message where buttons are present
 - `.channel` [discord.TextChannel](https://discordpy.readthedocs.io/en/latest/api.html#discord.TextChannel) : The channel where buttons are present.
 - `.guild` [discord.Guild](https://discordpy.readthedocs.io/en/latest/api.html#discord.Guild) : The guild where buttons are present.
-- `.member` [discord.User](https://discordpy.readthedocs.io/en/latest/api.html#discord.User) : The user who clicked the button. Remember this is `discord.User` and not `discord.Member`
+- `.member` [discord.Member](https://discordpy.readthedocs.io/en/stable/api.html#member) : The member who clicked the button.
 
 #### Methods:
 - `await .reply(content=None, *, channel=None, tts=False, embed=None, flags=None)`:

--- a/discord_buttons_plugin/models.py
+++ b/discord_buttons_plugin/models.py
@@ -28,9 +28,9 @@ class InteractionContext:
 		if not self.guild:
 			self.guild = await self.bot.fetch_guild(int(data["guild_id"]))
 
-		self.member = self.bot.get_user(int(data["member"]["user"]["id"]))
+		self.member = self.guild.get_member(int(data["member"]["user"]["id"]))
 		if not self.member:
-			self.member = await self.bot.fetch_user(int(data["member"]["user"]["id"]))
+			self.member = await self.guild.fetch_member(int(data["member"]["user"]["id"]))
 
 		self.message = await self.channel.fetch_message(int(data["message"]["id"]))
 		self.data = await ContextData().from_json(data["data"])


### PR DESCRIPTION
Modify InteractionContext.member to return a [discord.Member](https://discordpy.readthedocs.io/en/stable/api.html#member) object instead of [discord.User](https://discordpy.readthedocs.io/en/stable/api.html#discord.User).